### PR TITLE
feat(match): server-authoritative match + move sync (server core)

### DIFF
--- a/docs/05-improvement-plan.md
+++ b/docs/05-improvement-plan.md
@@ -24,10 +24,9 @@ I'd do first.
    of the store-coupled `moves.ts` into a `$lib/game` module that takes an
    explicit board state (no Svelte stores), with `isLegalMove` / `applyMove`.
    Fully unit-testable; the authority the MATCH flow needs.
-2. **MATCH flow + move sync** — join a room → `MATCH:<roomId>` topic, both
-   players subscribe, moves published as structured messages, validated on the
-   server (step 1) and applied on both boards. The headline "connect two
-   players" feature.
+2. **MATCH flow + move sync** — 🟡 **server core done** (feat/match-flow, with
+   captures + king-capture win, e2e-verified); **client 3D wiring remains** —
+   see [08-match-flow-next-steps.md](08-match-flow-next-steps.md).
 3. **Roll-your-own auth** (Tier 2 below) — remove Lucia, hand-rolled sessions.
 
 - ✅ **Room listing snapshot** (done, feat/room-persistence): `room` table via

--- a/docs/08-match-flow-next-steps.md
+++ b/docs/08-match-flow-next-steps.md
@@ -1,0 +1,81 @@
+# MATCH flow — status & next steps
+
+*Branch `feat/match-flow` (stacked on `feat/game-rules` → `feat/room-persistence`).
+Server core is done and tested; the client 3D wiring is the remaining work.*
+
+## Done (server core — verified)
+
+Server-authoritative match with turns, colours, captures, and king-capture win.
+
+- **`game` table** (`prisma/schema.prisma` + migration `20260705165733_add_game`):
+  `id, roomId, whitePlayerId, blackPlayerId, board (Json), turn, status,
+  winnerId, moves (Json), timestamps`. Applied to the dev DB.
+- **`src/lib/server/game/logic.ts`** (pure): `assignColors` and `decideMove`
+  (enforces turn order, piece ownership, legality via `$lib/game/rules`, capture
+  detection, king-capture → win). 9 unit tests.
+- **`src/lib/server/game/service.ts`** (DB + broadcast): `joinRoom`
+  (creates the game, closes the room, announces `game_started` on ROOMS),
+  `getGame`, `applyPlayerMove` (validates, persists, broadcasts `move_applied`
+  on `MATCH:<gameId>`).
+- **Routes**: `POST /api/rooms/[id]/join`, `GET /api/games/[id]`,
+  `POST /api/games/[id]/move`.
+- **Protocol** (`src/lib/async/websockets/types.ts`): `RoomDelta` gains
+  `game_started`; new `MatchDelta` (`move_applied`).
+- **e2e verified** (two logged-in players over HTTP + WS): create → join →
+  both get `game_started` → subscribe `MATCH:<id>` → white moves (both receive
+  `move_applied`, turn flips) → out-of-turn / opponent-piece / illegal all
+  rejected (409) → participant GET ok, unauth 401.
+
+### Move protocol (as built)
+
+```
+Owner creates room (picks side) ──▶ ROOMS: room_added
+Joiner POST /api/rooms/:id/join  ──▶ ROOMS: room_removed + game_started {game}
+  both clients then POST /api/add {client_id, topic:"MATCH:<gameId>"}
+Player POST /api/games/:id/move {from:[x,y,z], to:[x,y,z]}
+  server validates ──▶ MATCH:<gameId>: move_applied {from,to,turn,board,status,winnerId,captured}
+```
+
+## Next steps (client 3D wiring — NOT started)
+
+This is the part that needs the running app + human eyes (can't be click-tested
+headlessly). All server pieces it needs already exist.
+
+1. **Join from the lobby** — `Table.svelte` `onSelected` currently opens a
+   confirm modal that only `console.log`s. On confirm, `POST
+   /api/rooms/[id]/join`, take `game.id` from the response, subscribe the socket
+   to `MATCH:<id>` (via the existing `/api/add`), store the game, set
+   `playing = true`.
+2. **Owner side** — the owner learns the game started from the `game_started`
+   delta on ROOMS (already handled shape-wise in `roomsEventHandler` — add a
+   `case 'game_started'`): subscribe to `MATCH:<id>`, load `GET /api/games/[id]`,
+   set `playing = true`.
+3. **Game store** — add `src/lib/store/game.ts` holding `{ gameId, myColor,
+   turn, status, board }`. Seed it from `GET /api/games/[id]`; hydrate the 3D
+   board (`$lib/store` `board`) from `game.board` instead of the hardcoded
+   `putPieces` when in a match.
+4. **Send moves** — in `CubeStatus.svelte`, `addToMovePiece` currently calls the
+   local `movePiece`. In a match, instead `POST /api/games/[id]/move {from,to}`
+   and let the `move_applied` delta drive the board (don't apply optimistically,
+   or apply then reconcile).
+5. **Apply remote moves** — a `matchEventHandler` for `MATCH:<id>` messages:
+   on `move_applied`, apply `movePiece(from,to)` (and clear the captured square),
+   update turn/status; on `status:'finished'`, show win/lose.
+6. **Turn/colour gating** — only allow selecting your own pieces and only on your
+   turn; the server already rejects violations, this is just UX.
+7. **Reconcile client highlights with captures** — `$lib/utils/moves.ts` (client
+   highlight geometry) still models empty-only moves; point it at
+   `$lib/game/rules.ts` so capturable squares highlight. (Server already allows
+   captures.)
+
+## Follow-ups / known gaps
+
+- **No check/checkmate** — the win condition is literally capturing the king
+  (deliberate for now; documented). Real check detection is a later rules pass.
+- **No pawn promotion, no castling, no en passant** — not modelled.
+- **Reconnect** — `GET /api/games/[id]` returns full state for rehydration, but
+  the client doesn't yet resubscribe to `MATCH` on reload.
+- **Abandonment / resign / draw** — no lifecycle beyond active→finished-by-king.
+- **Spectators** — trivial to add later (extra subscribers on the MATCH topic).
+- The two Lucia v2 traps still apply (see `docs/05`): `session.user` has only
+  `userId`; non-GET `validate()` needs a matching `Origin` header.

--- a/prisma/migrations/20260705165733_add_game/migration.sql
+++ b/prisma/migrations/20260705165733_add_game/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "game" (
+    "id" TEXT NOT NULL,
+    "roomId" BIGINT,
+    "whitePlayerId" TEXT NOT NULL,
+    "blackPlayerId" TEXT NOT NULL,
+    "board" JSONB NOT NULL,
+    "turn" TEXT NOT NULL DEFAULT 'white',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "winnerId" TEXT,
+    "moves" JSONB NOT NULL DEFAULT '[]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "game_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "game_status_idx" ON "game"("status");
+
+-- AddForeignKey
+ALTER TABLE "game" ADD CONSTRAINT "game_whitePlayerId_fkey" FOREIGN KEY ("whitePlayerId") REFERENCES "auth_user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "game" ADD CONSTRAINT "game_blackPlayerId_fkey" FOREIGN KEY ("blackPlayerId") REFERENCES "auth_user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,8 +18,29 @@ model AuthUser {
   auth_session AuthSession[]
   auth_key     AuthKey[]
   rooms        Room[]
+  white_games  Game[]        @relation("WhiteGames")
+  black_games  Game[]        @relation("BlackGames")
 
   @@map("auth_user")
+}
+
+model Game {
+  id            String   @id @default(uuid())
+  roomId        BigInt?
+  whitePlayerId String
+  blackPlayerId String
+  board         Json
+  turn          String   @default("white")
+  status        String   @default("active")
+  winnerId      String?
+  moves         Json     @default("[]")
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  whitePlayer   AuthUser @relation("WhiteGames", references: [id], fields: [whitePlayerId], onDelete: Cascade)
+  blackPlayer   AuthUser @relation("BlackGames", references: [id], fields: [blackPlayerId], onDelete: Cascade)
+
+  @@index([status])
+  @@map("game")
 }
 
 model Room {

--- a/src/lib/async/websockets/types.ts
+++ b/src/lib/async/websockets/types.ts
@@ -1,9 +1,31 @@
 import type { Room } from '$lib/store/rooms';
+import type { Coord, PieceState, Side } from '$lib/game/rules';
 
 export type TOPICS = 'ROOMS' | 'MATCH' | string;
+
+/** Announced to both participants so a game can be joined by its id. */
+export type GameSummary = {
+	id: string;
+	roomId: number | null;
+	whitePlayerId: string;
+	blackPlayerId: string;
+};
 
 // Deltas broadcast on the ROOMS topic. The full room list is fetched once as a
 // snapshot on load; these keep every connected lobby in sync afterwards.
 export type RoomDelta =
 	| { kind: 'room_added'; room: Room }
-	| { kind: 'room_removed'; id: number };
+	| { kind: 'room_removed'; id: number }
+	| { kind: 'game_started'; game: GameSummary };
+
+// Deltas broadcast on the per-game MATCH:<gameId> topic.
+export type MatchDelta = {
+	kind: 'move_applied';
+	from: Coord;
+	to: Coord;
+	turn: Side;
+	board: Record<string, PieceState>;
+	status: 'active' | 'finished';
+	winnerId: string | null;
+	captured: PieceState | null;
+};

--- a/src/lib/server/game/logic.test.ts
+++ b/src/lib/server/game/logic.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { assignColors, decideMove } from './logic';
+import { boardToObject, initialBoard, type PieceState } from '$lib/game/rules';
+
+describe('assignColors', () => {
+	it('gives the owner their chosen side', () => {
+		expect(assignColors('white', 'owner', 'joiner')).toEqual({
+			whitePlayerId: 'owner',
+			blackPlayerId: 'joiner'
+		});
+		expect(assignColors('black', 'owner', 'joiner')).toEqual({
+			whitePlayerId: 'joiner',
+			blackPlayerId: 'owner'
+		});
+	});
+
+	it('randomises when the owner picked "random"', () => {
+		expect(assignColors('random', 'owner', 'joiner', () => 0.1).whitePlayerId).toBe('owner');
+		expect(assignColors('random', 'owner', 'joiner', () => 0.9).whitePlayerId).toBe('joiner');
+	});
+});
+
+describe('decideMove', () => {
+	const start = boardToObject(initialBoard());
+
+	it('rejects moving out of turn', () => {
+		const r = decideMove(start, 'white', 'black', [2, 6, 2], [2, 5, 2]);
+		expect(r).toEqual({ ok: false, error: 'Not your turn' });
+	});
+
+	it('rejects moving from an empty square', () => {
+		const r = decideMove(start, 'white', 'white', [4, 4, 4], [4, 5, 4]);
+		expect(r).toEqual({ ok: false, error: 'No piece on the source square' });
+	});
+
+	it("rejects moving the opponent's piece", () => {
+		// white's turn, white tries to move a black pawn
+		const r = decideMove(start, 'white', 'white', [2, 6, 2], [2, 5, 2]);
+		expect(r).toEqual({ ok: false, error: 'That piece is not yours' });
+	});
+
+	it('rejects an illegal destination', () => {
+		const r = decideMove(start, 'white', 'white', [2, 1, 2], [7, 7, 7]);
+		expect(r).toEqual({ ok: false, error: 'Illegal move' });
+	});
+
+	it('accepts a legal move: flips the turn and moves the piece', () => {
+		const r = decideMove(start, 'white', 'white', [2, 1, 2], [2, 2, 2]);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.turn).toBe('black');
+		expect(r.captured).toBeNull();
+		expect(r.winnerSide).toBeNull();
+		expect(r.board['2,2,2']).toEqual({ piece: 'pawn', side: 'white' });
+		expect(r.board['2,1,2']).toBeUndefined();
+	});
+
+	it('records a capture', () => {
+		const board: Record<string, PieceState> = {
+			'0,0,0': { piece: 'rook', side: 'white' },
+			'0,0,2': { piece: 'knight', side: 'black' }
+		};
+		const r = decideMove(board, 'white', 'white', [0, 0, 0], [0, 0, 2]);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.captured).toEqual({ piece: 'knight', side: 'black' });
+		expect(r.board['0,0,2']).toEqual({ piece: 'rook', side: 'white' });
+		expect(r.winnerSide).toBeNull();
+	});
+
+	it('capturing the king wins the game', () => {
+		const board: Record<string, PieceState> = {
+			'0,0,0': { piece: 'rook', side: 'white' },
+			'0,0,1': { piece: 'king', side: 'black' }
+		};
+		const r = decideMove(board, 'white', 'white', [0, 0, 0], [0, 0, 1]);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.captured).toEqual({ piece: 'king', side: 'black' });
+		expect(r.winnerSide).toBe('white');
+	});
+});

--- a/src/lib/server/game/logic.ts
+++ b/src/lib/server/game/logic.ts
@@ -1,0 +1,75 @@
+// Pure game-decision logic: no DB, no stores. The service layer loads/saves and
+// broadcasts; everything that decides *whether a move is allowed and what the
+// board becomes* lives here so it can be unit-tested in isolation.
+import {
+	objectToBoard,
+	boardToObject,
+	pieceAt,
+	isLegalMove,
+	applyMove,
+	type Coord,
+	type Side,
+	type PieceState
+} from '$lib/game/rules';
+
+export type RoomSide = 'white' | 'black' | 'random' | '';
+
+/** Decide colours when a second player joins. Owner gets their chosen side. */
+export function assignColors(
+	ownerSide: RoomSide,
+	ownerId: string,
+	joinerId: string,
+	rand: () => number = Math.random
+): { whitePlayerId: string; blackPlayerId: string } {
+	let ownerIsWhite: boolean;
+	if (ownerSide === 'white') ownerIsWhite = true;
+	else if (ownerSide === 'black') ownerIsWhite = false;
+	else ownerIsWhite = rand() < 0.5;
+
+	return ownerIsWhite
+		? { whitePlayerId: ownerId, blackPlayerId: joinerId }
+		: { whitePlayerId: joinerId, blackPlayerId: ownerId };
+}
+
+export type MoveDecision =
+	| { ok: false; error: string }
+	| {
+			ok: true;
+			board: Record<string, PieceState>;
+			turn: Side;
+			captured: PieceState | null;
+			winnerSide: Side | null;
+	  };
+
+/**
+ * Validate and resolve a move against a serialized board. Enforces turn order,
+ * piece ownership, and legality (via the rules module), and detects a
+ * king capture as an immediate win.
+ */
+export function decideMove(
+	boardObj: Record<string, PieceState>,
+	turn: Side,
+	playerSide: Side,
+	from: Coord,
+	to: Coord
+): MoveDecision {
+	if (playerSide !== turn) return { ok: false, error: 'Not your turn' };
+
+	const board = objectToBoard(boardObj);
+	const moving = pieceAt(board, from);
+	if (!moving) return { ok: false, error: 'No piece on the source square' };
+	if (moving.side !== playerSide) return { ok: false, error: 'That piece is not yours' };
+	if (!isLegalMove(board, from, to)) return { ok: false, error: 'Illegal move' };
+
+	const captured = pieceAt(board, to);
+	const next = applyMove(board, from, to);
+	const winnerSide = captured?.piece === 'king' ? playerSide : null;
+
+	return {
+		ok: true,
+		board: boardToObject(next),
+		turn: playerSide === 'white' ? 'black' : 'white',
+		captured,
+		winnerSide
+	};
+}

--- a/src/lib/server/game/service.ts
+++ b/src/lib/server/game/service.ts
@@ -1,0 +1,149 @@
+import { prisma } from '$lib/server/prisma';
+import { publish } from '$lib/server/ws/registry.js';
+import { initialBoard, boardToObject, type Coord, type PieceState, type Side } from '$lib/game/rules';
+import type { GameSummary, MatchDelta, RoomDelta } from '$lib/async/websockets/types';
+import { assignColors, decideMove, type RoomSide } from './logic';
+
+const ROOMS_TOPIC = 'ROOMS';
+const matchTopic = (gameId: string) => `MATCH:${gameId}`;
+
+export type GameState = GameSummary & {
+	board: Record<string, PieceState>;
+	turn: Side;
+	status: 'active' | 'finished';
+	winnerId: string | null;
+	moves: unknown[];
+};
+
+// prisma returns board/moves as JsonValue; these rows are only ever written by
+// this service, so the shapes are known.
+type GameRow = {
+	id: string;
+	roomId: bigint | null;
+	whitePlayerId: string;
+	blackPlayerId: string;
+	board: unknown;
+	turn: string;
+	status: string;
+	winnerId: string | null;
+	moves: unknown;
+};
+
+function toSummary(g: GameRow): GameSummary {
+	return {
+		id: g.id,
+		roomId: g.roomId === null ? null : Number(g.roomId),
+		whitePlayerId: g.whitePlayerId,
+		blackPlayerId: g.blackPlayerId
+	};
+}
+
+function toState(g: GameRow): GameState {
+	return {
+		...toSummary(g),
+		board: g.board as Record<string, PieceState>,
+		turn: g.turn as Side,
+		status: g.status as 'active' | 'finished',
+		winnerId: g.winnerId,
+		moves: g.moves as unknown[]
+	};
+}
+
+function broadcastRooms(delta: RoomDelta) {
+	publish(ROOMS_TOPIC, JSON.stringify(delta));
+}
+
+/**
+ * A second player joins an open room: create the game, close the room, and
+ * announce the game on the ROOMS topic so both participants (already subscribed
+ * there) can subscribe to MATCH:<gameId> and start playing.
+ */
+export async function joinRoom(roomId: number, joinerId: string): Promise<GameState> {
+	const room = await prisma.room.findFirst({ where: { id: BigInt(roomId), status: 'open' } });
+	if (!room) throw new Error('ROOM_NOT_OPEN');
+	if (room.ownerId === joinerId) throw new Error('CANNOT_JOIN_OWN_ROOM');
+
+	const { whitePlayerId, blackPlayerId } = assignColors(
+		room.side as RoomSide,
+		room.ownerId,
+		joinerId
+	);
+
+	const game = await prisma.game.create({
+		data: {
+			roomId: BigInt(roomId),
+			whitePlayerId,
+			blackPlayerId,
+			board: boardToObject(initialBoard()),
+			turn: 'white',
+			status: 'active',
+			moves: []
+		}
+	});
+
+	await prisma.room.update({ where: { id: BigInt(roomId) }, data: { status: 'playing' } });
+	broadcastRooms({ kind: 'room_removed', id: roomId });
+	broadcastRooms({ kind: 'game_started', game: toSummary(game) });
+
+	return toState(game);
+}
+
+export async function getGame(gameId: string): Promise<GameState | null> {
+	const game = await prisma.game.findUnique({ where: { id: gameId } });
+	return game ? toState(game) : null;
+}
+
+/**
+ * Validate a move server-side and, if legal, persist the new board and broadcast
+ * it to both players on the MATCH topic. Throws with a machine-readable message
+ * the route maps to a 4xx.
+ */
+export async function applyPlayerMove(
+	gameId: string,
+	playerId: string,
+	from: Coord,
+	to: Coord
+): Promise<GameState> {
+	const game = await prisma.game.findUnique({ where: { id: gameId } });
+	if (!game) throw new Error('GAME_NOT_FOUND');
+	if (game.status !== 'active') throw new Error('GAME_OVER');
+
+	const playerSide: Side | null =
+		playerId === game.whitePlayerId ? 'white' : playerId === game.blackPlayerId ? 'black' : null;
+	if (!playerSide) throw new Error('NOT_A_PARTICIPANT');
+
+	const decision = decideMove(
+		game.board as Record<string, PieceState>,
+		game.turn as Side,
+		playerSide,
+		from,
+		to
+	);
+	if (!decision.ok) throw new Error(decision.error);
+
+	const status = decision.winnerSide ? 'finished' : 'active';
+	const winnerId = decision.winnerSide ? playerId : null;
+	const moves = [
+		...(game.moves as unknown[]),
+		{ from, to, side: playerSide, captured: decision.captured }
+	];
+
+	const updated = await prisma.game.update({
+		where: { id: gameId },
+		data: { board: decision.board, turn: decision.turn, status, winnerId, moves }
+	});
+
+	const delta: MatchDelta = {
+		kind: 'move_applied',
+		from,
+		to,
+		turn: decision.turn,
+		board: decision.board,
+		status,
+		winnerId,
+		captured: decision.captured
+	};
+	publish(matchTopic(gameId), JSON.stringify(delta));
+
+	return toState(updated);
+}

--- a/src/routes/api/games/[id]/+server.ts
+++ b/src/routes/api/games/[id]/+server.ts
@@ -1,0 +1,18 @@
+import { json, error } from '@sveltejs/kit';
+import { getGame } from '$lib/server/game/service';
+
+// Game state snapshot — for a joining player or a reconnect.
+export const GET = async ({ params, locals }) => {
+	const session = await locals.auth.validate();
+	if (!session) throw error(401, 'Not authenticated');
+
+	const game = await getGame(params.id);
+	if (!game) throw error(404, 'Game not found');
+
+	const uid = session.user.userId;
+	if (uid !== game.whitePlayerId && uid !== game.blackPlayerId) {
+		throw error(403, 'Not a participant');
+	}
+
+	return json({ game });
+};

--- a/src/routes/api/games/[id]/move/+server.ts
+++ b/src/routes/api/games/[id]/move/+server.ts
@@ -1,0 +1,40 @@
+import { json, error } from '@sveltejs/kit';
+import { z } from 'zod';
+import { applyPlayerMove } from '$lib/server/game/service';
+import type { Coord } from '$lib/game/rules';
+
+const coord = z.tuple([z.number().int(), z.number().int(), z.number().int()]);
+const moveSchema = z.object({ from: coord, to: coord });
+
+// Move-decision errors from the service map to 409 (conflict); the rest are 5xx.
+const MOVE_ERRORS = new Set([
+	'Not your turn',
+	'No piece on the source square',
+	'That piece is not yours',
+	'Illegal move',
+	'GAME_OVER'
+]);
+
+export const POST = async ({ params, request, locals }) => {
+	const session = await locals.auth.validate();
+	if (!session) throw error(401, 'Not authenticated');
+
+	const parsed = moveSchema.safeParse(await request.json());
+	if (!parsed.success) throw error(400, 'Invalid move');
+
+	try {
+		const game = await applyPlayerMove(
+			params.id,
+			session.user.userId,
+			parsed.data.from as Coord,
+			parsed.data.to as Coord
+		);
+		return json({ game });
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : 'UNKNOWN';
+		if (msg === 'GAME_NOT_FOUND') throw error(404, msg);
+		if (msg === 'NOT_A_PARTICIPANT') throw error(403, msg);
+		if (MOVE_ERRORS.has(msg)) throw error(409, msg);
+		throw error(500, msg);
+	}
+};

--- a/src/routes/api/rooms/[id]/join/+server.ts
+++ b/src/routes/api/rooms/[id]/join/+server.ts
@@ -1,0 +1,23 @@
+import { json, error } from '@sveltejs/kit';
+import { joinRoom } from '$lib/server/game/service';
+
+const STATUS: Record<string, number> = {
+	ROOM_NOT_OPEN: 404,
+	CANNOT_JOIN_OWN_ROOM: 409
+};
+
+export const POST = async ({ params, locals }) => {
+	const session = await locals.auth.validate();
+	if (!session) throw error(401, 'Not authenticated');
+
+	const roomId = Number(params.id);
+	if (!Number.isFinite(roomId)) throw error(400, 'Invalid room id');
+
+	try {
+		const game = await joinRoom(roomId, session.user.userId);
+		return json({ game }, { status: 201 });
+	} catch (e) {
+		const code = e instanceof Error ? e.message : 'UNKNOWN';
+		throw error(STATUS[code] ?? 500, code);
+	}
+};


### PR DESCRIPTION
Stacked on #6 (feat/game-rules). Step 2 of the sequenced Tier 1 plan — **server core only**; client 3D wiring is documented as next steps.

## What
Server-authoritative match play with turns, colours, captures, and king-capture win, all validated server-side.

- `game` table (+ migration), `AuthUser` white/black game relations
- `src/lib/server/game/logic.ts` (pure): `assignColors` + `decideMove` (turn order, piece ownership, legality via `$lib/game/rules`, capture detection, king-capture → win)
- `src/lib/server/game/service.ts`: `joinRoom` (create game, close room, announce `game_started` on ROOMS), `getGame`, `applyPlayerMove` (validate → persist → broadcast `move_applied` on `MATCH:<gameId>`)
- Routes: `POST /api/rooms/[id]/join`, `GET /api/games/[id]`, `POST /api/games/[id]/move`
- Protocol: `RoomDelta` gains `game_started`; new `MatchDelta`

## Verification
- 49 unit tests green (incl. 9 game-logic)
- Two-player e2e over HTTP+WS: create → join → both get `game_started` → subscribe `MATCH` → white moves (both receive `move_applied`, turn flips) → out-of-turn / opponent-piece / illegal all 409 → participant GET ok, unauth 401

## Not in this PR (see docs/08-match-flow-next-steps.md)
Client 3D wiring: join from the lobby table, subscribe MATCH, send moves from `CubeStatus`, apply remote moves, turn/colour gating, reconcile client highlight geometry with captures. Needs the running app + human eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)