### PR TITLE
feat(reconnect): rejoin your active game after a reload + in-repo e2e suite

### DIFF
--- a/e2e/auth.e2e.mjs
+++ b/e2e/auth.e2e.mjs
@@ -1,0 +1,76 @@
+import { BASE, assert, finish, getCookie } from './helpers.mjs';
+
+const COOKIE = 'hyperchess_session';
+const cookieAttrs = (res) =>
+	(res.headers.getSetCookie?.() ?? []).find((c) => c.startsWith(`${COOKIE}=`)) ?? '';
+
+const uname = `e2e_${Date.now().toString().slice(-7)}`;
+
+// 1. signup sets a session cookie with the right attributes
+const signup = await fetch(`${BASE}/signup`, {
+	method: 'POST',
+	headers: { 'content-type': 'application/x-www-form-urlencoded', origin: BASE },
+	body: new URLSearchParams({ name: 'E2E User', username: uname, password: 'secret123', email: `${uname}@x.com` }),
+	redirect: 'manual'
+});
+let cookie = getCookie(signup);
+assert(!!cookie, `signup set ${COOKIE} cookie (status ${signup.status})`);
+const attrs = cookieAttrs(signup);
+assert(/HttpOnly/i.test(attrs), 'cookie is HttpOnly');
+assert(/SameSite=Lax/i.test(attrs), 'cookie is SameSite=Lax');
+assert(!/Secure/i.test(attrs), 'cookie has no Secure on localhost');
+
+const authed = (c) => (path, opts = {}) =>
+	fetch(`${BASE}${path}`, { ...opts, headers: { ...(opts.headers || {}), cookie: c, origin: BASE } });
+
+// 2. authenticated → lobby loads
+let r = await authed(cookie)('/', { redirect: 'manual' });
+assert(r.status === 200, `authed GET / is 200 (got ${r.status})`);
+
+// 3. a JSON POST works WITHOUT an Origin header
+r = await fetch(`${BASE}/api/rooms`, {
+	method: 'POST',
+	headers: { 'content-type': 'application/json', cookie },
+	body: JSON.stringify({ time: '5+5', style: 'match', side: 'white', privacy: 'public' })
+});
+assert(r.status === 201 || r.status === 200, `authed JSON POST works with no Origin header (got ${r.status})`);
+// clean up the room we just made
+const { room } = await r.clone().json().catch(() => ({ room: null }));
+if (room) await authed(cookie)(`/api/rooms/${room.id}`, { method: 'DELETE' });
+
+// 4. logout invalidates the session
+r = await authed(cookie)('/api/logout', { method: 'POST' });
+assert(r.status === 200, `logout 200 (got ${r.status})`);
+r = await authed(cookie)('/', { redirect: 'manual' });
+assert(r.status === 302, `after logout GET / redirects to login (got ${r.status})`);
+
+// 5. login again
+const loginRes = await fetch(`${BASE}/login`, {
+	method: 'POST',
+	headers: { 'content-type': 'application/x-www-form-urlencoded', origin: BASE },
+	body: new URLSearchParams({ username: uname, password: 'secret123' }),
+	redirect: 'manual'
+});
+cookie = getCookie(loginRes);
+assert(!!cookie, `login set a fresh cookie (status ${loginRes.status})`);
+r = await authed(cookie)('/', { redirect: 'manual' });
+assert(r.status === 200, `re-login authenticates (got ${r.status})`);
+
+// 6. wrong password rejected
+const bad = await fetch(`${BASE}/login`, {
+	method: 'POST',
+	headers: { 'content-type': 'application/x-www-form-urlencoded', origin: BASE },
+	body: new URLSearchParams({ username: uname, password: 'WRONGPASS' }),
+	redirect: 'manual'
+});
+assert(!getCookie(bad), 'wrong password sets no session cookie');
+
+// 7. cross-origin form POST blocked by CSRF
+const csrf = await fetch(`${BASE}/login`, {
+	method: 'POST',
+	headers: { 'content-type': 'application/x-www-form-urlencoded', origin: 'http://evil.example' },
+	body: new URLSearchParams({ username: uname, password: 'secret123' })
+});
+assert(csrf.status === 403, `cross-origin form POST blocked by CSRF (got ${csrf.status})`);
+
+finish('AUTH E2E');

--- a/e2e/helpers.mjs
+++ b/e2e/helpers.mjs
@@ -1,0 +1,62 @@
+import WebSocket from 'ws';
+
+export const BASE = process.env.BASE || 'http://localhost:5173';
+
+let failures = 0;
+export const assert = (cond, msg) => {
+	console.log(`${cond ? 'ok  -' : 'FAIL:'} ${msg}`);
+	if (!cond) failures++;
+};
+export const finish = (name) => {
+	console.log(`\n${failures === 0 ? `${name} OK` : `${name} FAILED (${failures})`}`);
+	process.exit(failures === 0 ? 0 : 1);
+};
+
+export const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export const getCookie = (res, name = 'hyperchess_session') =>
+	(res.headers.getSetCookie?.() ?? [])
+		.map((c) => c.split(';')[0])
+		.filter((c) => c.startsWith(`${name}=`))
+		.pop();
+
+/** Login and return an authenticated fetch (cookie + Origin, like a browser). */
+export async function login(username, password = 'secret123') {
+	const res = await fetch(`${BASE}/login`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/x-www-form-urlencoded', origin: BASE },
+		body: new URLSearchParams({ username, password }),
+		redirect: 'manual'
+	});
+	const cookie = getCookie(res);
+	if (!cookie) throw new Error(`login failed for ${username} (${res.status})`);
+	return (path, opts = {}) =>
+		fetch(`${BASE}${path}`, { ...opts, headers: { ...(opts.headers || {}), cookie, origin: BASE } });
+}
+
+/** Register a ws client on a topic and connect; returns { clientId, ws, msgs }. */
+export async function connectWsClient(userId, topic = 'ROOMS') {
+	const reg = await (
+		await fetch(`${BASE}/api/ws`, {
+			method: 'POST',
+			headers: { origin: BASE },
+			body: JSON.stringify({ user_id: userId, topic })
+		})
+	).json();
+	const clientId = reg.result.client_id;
+	const ws = new WebSocket(`${BASE.replace('http', 'ws')}/ws/${clientId}`);
+	const msgs = [];
+	ws.on('message', (d) => msgs.push(JSON.parse(d.toString())));
+	await new Promise((ok, bad) => {
+		ws.once('open', ok);
+		ws.once('error', bad);
+	});
+	return { clientId, ws, msgs };
+}
+
+export const addTopic = (clientId, topic) =>
+	fetch(`${BASE}/api/add`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json', origin: BASE },
+		body: JSON.stringify({ client_id: clientId, topic })
+	});

--- a/e2e/match.e2e.mjs
+++ b/e2e/match.e2e.mjs
@@ -1,0 +1,102 @@
+import { BASE, assert, finish, login, connectWsClient, addTopic, wait } from './helpers.mjs';
+
+const p1 = await login('testplayer'); // owner, will pick white
+const p2 = await login('prodplayer'); // joiner
+
+const c1 = await connectWsClient('testplayer');
+const c2 = await connectWsClient('prodplayer');
+
+// clean slate
+for (const r of (await (await p1('/api/rooms')).json()).rooms.filter((r) => r.owner.username === 'testplayer')) {
+	await p1(`/api/rooms/${r.id}`, { method: 'DELETE' });
+}
+
+// NOTE: earlier runs may leave active games (no resign/abandon endpoint yet);
+// /api/games/current returns the NEWEST active game, so the assertions below
+// stay valid on repeat runs.
+
+// create + join
+const createRes = await p1('/api/rooms', {
+	method: 'POST',
+	headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({ time: 'unlimited', style: 'match', side: 'white', privacy: 'public' })
+});
+const { room } = await createRes.json();
+assert(createRes.status === 201, 'p1 created a room (white)');
+await wait(200);
+assert(c2.msgs.some((m) => m.kind === 'room_added' && m.room.id === room.id), 'p2 saw room_added');
+
+const joinRes = await p2(`/api/rooms/${room.id}/join`, { method: 'POST' });
+assert(joinRes.status === 201, `p2 joined (201, got ${joinRes.status})`);
+const { game } = await joinRes.json();
+assert(game.whitePlayerId !== game.blackPlayerId, 'game has two distinct players');
+
+await wait(200);
+assert(c1.msgs.some((m) => m.kind === 'game_started' && m.game.id === game.id), 'p1 (owner) received game_started');
+assert(c2.msgs.some((m) => m.kind === 'game_started' && m.game.id === game.id), 'p2 (joiner) received game_started');
+assert(c1.msgs.some((m) => m.kind === 'room_removed' && m.id === room.id), 'lobby got room_removed');
+
+// reconnect endpoint: both players' current game is this one
+const cur1 = await (await p1('/api/games/current')).json();
+const cur2 = await (await p2('/api/games/current')).json();
+assert(cur1.game?.id === game.id, 'GET /api/games/current returns the game for p1 (reconnect)');
+assert(cur2.game?.id === game.id, 'GET /api/games/current returns the game for p2 (reconnect)');
+const curNoAuth = await fetch(`${BASE}/api/games/current`);
+assert(curNoAuth.status === 401, 'unauthenticated /api/games/current rejected');
+
+// subscribe both to the MATCH topic
+const topic = `MATCH:${game.id}`;
+await addTopic(c1.clientId, topic);
+await addTopic(c2.clientId, topic);
+
+// white (p1) moves
+const m1 = await p1(`/api/games/${game.id}/move`, {
+	method: 'POST',
+	headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({ from: [2, 1, 2], to: [2, 2, 2] })
+});
+assert(m1.status === 200, `white move accepted (200, got ${m1.status})`);
+await wait(200);
+assert(
+	c1.msgs.some((m) => m.kind === 'move_applied') && c2.msgs.some((m) => m.kind === 'move_applied'),
+	'both players received move_applied'
+);
+assert(
+	[...c1.msgs, ...c2.msgs].filter((m) => m.kind === 'move_applied').every((m) => m.turn === 'black'),
+	'turn advanced to black'
+);
+
+// violations
+const outOfTurn = await p1(`/api/games/${game.id}/move`, {
+	method: 'POST', headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({ from: [3, 1, 3], to: [3, 2, 3] })
+});
+assert(outOfTurn.status === 409, `out-of-turn move rejected (409, got ${outOfTurn.status})`);
+
+const blackMove = await p2(`/api/games/${game.id}/move`, {
+	method: 'POST', headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({ from: [2, 6, 2], to: [2, 5, 2] })
+});
+assert(blackMove.status === 200, `black move accepted (200, got ${blackMove.status})`);
+
+const foreign = await p1(`/api/games/${game.id}/move`, {
+	method: 'POST', headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({ from: [3, 6, 3], to: [3, 5, 3] })
+});
+assert(foreign.status === 409, `moving opponent's piece rejected (409, got ${foreign.status})`);
+
+const illegal = await p1(`/api/games/${game.id}/move`, {
+	method: 'POST', headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({ from: [3, 1, 3], to: [7, 7, 7] })
+});
+assert(illegal.status === 409, `illegal move rejected (409, got ${illegal.status})`);
+
+// state access
+const stateRes = await p1(`/api/games/${game.id}`);
+assert(stateRes.status === 200, 'participant can GET game state');
+const unauth = await fetch(`${BASE}/api/games/${game.id}`);
+assert(unauth.status === 401, 'unauthenticated GET rejected');
+
+c1.ws.close();
+c2.ws.close();
+finish('MATCH E2E');

--- a/e2e/rooms.e2e.mjs
+++ b/e2e/rooms.e2e.mjs
@@ -1,0 +1,66 @@
+import { BASE, assert, finish, login, connectWsClient, wait } from './helpers.mjs';
+
+const authFetch = await login('testplayer');
+
+// a peer already connected to the ROOMS topic
+const peer = await connectWsClient('peer-watcher');
+
+// clean slate: remove any open rooms owned by testplayer
+const before = (await (await authFetch('/api/rooms')).json()).rooms;
+assert(Array.isArray(before), 'GET /api/rooms returns a snapshot array');
+for (const r of before.filter((r) => r.owner.username === 'testplayer')) {
+	await authFetch(`/api/rooms/${r.id}`, { method: 'DELETE' });
+}
+
+// create a room
+const createRes = await authFetch('/api/rooms', {
+	method: 'POST',
+	headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({ time: '5+5', style: 'match', side: 'white', privacy: 'public' })
+});
+assert(createRes.status === 201, `POST /api/rooms created (201, got ${createRes.status})`);
+const { room, created } = await createRes.json();
+assert(created === true && typeof room.id === 'number', 'created:true with numeric room id');
+
+await wait(300);
+assert(peer.msgs.some((d) => d.kind === 'room_added' && d.room.id === room.id), 'peer received room_added delta');
+
+// fresh snapshot includes it (late-joiner fix)
+const afterCreate = (await (await authFetch('/api/rooms')).json()).rooms;
+assert(afterCreate.some((r) => r.id === room.id), 'fresh snapshot includes the new room');
+
+// one open room per owner
+const dup = await authFetch('/api/rooms', {
+	method: 'POST',
+	headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({ time: '30+10', style: 'sandbox', side: 'black', privacy: 'private' })
+});
+const dupBody = await dup.json();
+assert(dup.status === 200 && dupBody.created === false && dupBody.room.id === room.id, 'second create returns the existing room');
+
+// invalid payload rejected
+const bad = await authFetch('/api/rooms', {
+	method: 'POST',
+	headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({ time: '5+5', style: 'blitz', side: 'white', privacy: 'public' })
+});
+assert(bad.status === 400, `invalid style rejected (400, got ${bad.status})`);
+
+// unauthenticated rejected
+const noauth = await fetch(`${BASE}/api/rooms`, {
+	method: 'POST',
+	headers: { 'content-type': 'application/json', origin: BASE },
+	body: JSON.stringify({ time: '5+5', style: 'match', side: 'white', privacy: 'public' })
+});
+assert(noauth.status === 401, `unauthenticated create rejected (401, got ${noauth.status})`);
+
+// cancel: delta + snapshot removal
+const del = await authFetch(`/api/rooms/${room.id}`, { method: 'DELETE' });
+assert(del.status === 200, `DELETE /api/rooms/${room.id} ok`);
+await wait(300);
+assert(peer.msgs.some((d) => d.kind === 'room_removed' && d.id === room.id), 'peer received room_removed delta');
+const afterDelete = (await (await authFetch('/api/rooms')).json()).rooms;
+assert(!afterDelete.some((r) => r.id === room.id), 'snapshot no longer includes the cancelled room');
+
+peer.ws.close();
+finish('ROOMS E2E');

--- a/e2e/seed.mjs
+++ b/e2e/seed.mjs
@@ -1,0 +1,18 @@
+// Ensure the two e2e players exist (idempotent: signup failures are fine if
+// the user already exists — login is what the suites rely on).
+const BASE = process.env.BASE || 'http://localhost:5173';
+
+for (const username of ['testplayer', 'prodplayer']) {
+	const res = await fetch(`${BASE}/signup`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/x-www-form-urlencoded', origin: BASE },
+		body: new URLSearchParams({
+			name: `${username} Player`,
+			username,
+			password: 'secret123',
+			email: `${username}@example.com`
+		}),
+		redirect: 'manual'
+	});
+	console.log(`seed ${username}: ${res.status}`);
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"format": "prettier --plugin-search-dir . --write .",
 		"test": "vitest run",
 		"test:watch": "vitest",
+		"e2e": "node e2e/seed.mjs && node e2e/auth.e2e.mjs && node e2e/rooms.e2e.mjs && node e2e/match.e2e.mjs",
 		"model-pipeline:run": "node scripts/model-pipeline.js"
 	},
 	"devDependencies": {

--- a/src/lib/server/game/service.ts
+++ b/src/lib/server/game/service.ts
@@ -93,6 +93,15 @@ export async function getGame(gameId: string): Promise<GameState | null> {
 	return game ? toState(game) : null;
 }
 
+/** The player's active game, if any — used to reconnect after a reload. */
+export async function getCurrentGameFor(userId: string): Promise<GameState | null> {
+	const game = await prisma.game.findFirst({
+		where: { status: 'active', OR: [{ whitePlayerId: userId }, { blackPlayerId: userId }] },
+		orderBy: { createdAt: 'desc' }
+	});
+	return game ? toState(game) : null;
+}
+
 /**
  * Validate a move server-side and, if legal, persist the new board and broadcast
  * it to both players on the MATCH topic. Throws with a machine-readable message

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,6 +10,7 @@
 	import { isLoading } from '$lib/store/loading';
 	import Spinner from '$lib/components/loading/Spinner.svelte';
 	import { roomsEventHandler } from '$lib/async/websockets/rooms/handler';
+	import { enterMatch } from '$lib/async/websockets/match/handler';
 	import { roomsStore } from '$lib/store/rooms';
 
 	let loading = false;
@@ -62,26 +63,37 @@
 				};
 			});
 	}
+	const rejoinActiveGame = async () => {
+		// reconnect after a reload: if the server has an active game for us,
+		// re-enter it (hydrates the board and re-subscribes the MATCH topic)
+		try {
+			const res = await fetch('/api/games/current');
+			if (!res.ok) return;
+			const { game } = await res.json();
+			if (game) await enterMatch(game);
+		} catch (e) {
+			console.error('Failed to check for an active game:', e);
+		}
+	};
+
 	onMount(() => {
 		console.log('on mount');
 		// seed the lobby from the server snapshot before deltas start arriving
 		roomsStore.set(data.rooms ?? []);
 		const currentUser = get(userStore);
-		let ws: WebSocket | null = null;
 		// Ensure that this code runs only on the client side and currentUser has required properties
 		if (currentUser && currentUser.id) {
 			registerClient('ROOMS', roomsEventHandler, currentUser)
 				.then((client) => {
 					if (client && client.readyState === 1) {
-						userStore.set({
-							...currentUser,
-							ws
-						});
+						// update, not set: registration just stored clientId in the store
+						userStore.update((u) => ({ ...u, ws: client }));
 						console.log('WebSocket connected');
 						pushNotification({
 							message: 'Rooms WebSocket connected',
 							type: 'success'
 						});
+						void rejoinActiveGame();
 					}
 				})
 				.catch((e) => {

--- a/src/routes/api/games/current/+server.ts
+++ b/src/routes/api/games/current/+server.ts
@@ -1,0 +1,8 @@
+import { json, error } from '@sveltejs/kit';
+import { getCurrentGameFor } from '$lib/server/game/service';
+
+// The caller's active game, if any (static segment wins over the [id] route).
+export const GET = async ({ locals }) => {
+	if (!locals.user) throw error(401, 'Not authenticated');
+	return json({ game: await getCurrentGameFor(locals.user.id) });
+};


### PR DESCRIPTION
Closes the biggest match-flow gap from docs/08: after a page reload you now land back in your active game.

## What
- **Server**: `getCurrentGameFor(userId)` (newest active game) + `GET /api/games/current`
- **Client**: after the lobby socket connects, `/api/games/current` is checked and the game re-entered — board re-hydrated from the server state, `MATCH:<id>` re-subscribed
- **Bug fix**: the post-connect `userStore.set(stale snapshot)` was wiping the just-stored ws `clientId` (which would have broken MATCH topic subscription) and stored `ws: null`; now a proper `update` with the live socket
- **E2E suite moves into the repo** (`e2e/`: helpers + seed + auth/rooms/match, `BASE` env-driven, `pnpm e2e`) — previously throwaway scratchpad scripts; groundwork for CI. Match suite now asserts the reconnect endpoint for both players + unauth 401

## Verified
- 54 unit tests green
- `pnpm e2e` (auth + rooms + match) green **twice in a row** (repeat runs tolerate leftover active games — no resign endpoint yet, documented)

## Manual check for the 3D side
Mid-game, hit F5: you should land back at the board with the current position and it's still whoever's turn it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)